### PR TITLE
making TwsApiCpp compile on Ubuntu + suppress some (71) warnings

### DIFF
--- a/TwsApiC++/Api/TwsApiL0.h
+++ b/TwsApiC++/Api/TwsApiL0.h
@@ -111,7 +111,7 @@ public:
 #if 1	// set to 0 to prevent this warning message in debug mode
 #ifdef _DEBUG
 #undef  EWRAPPERL0_DEFAULT
-#define EWRAPPERL0_DEFAULT(id, name) printf( "#warning: empty default method EWrapperL0::%s(id=%d) was called!\n", name, id );
+#define EWRAPPERL0_DEFAULT(id, name) printf( "#warning: empty default method EWrapperL0::%s(id=%ld) was called!\n", name, static_cast<long int>(id) );
 #endif
 #endif
 

--- a/TwsApiC++/_linux/debug/.gitignore
+++ b/TwsApiC++/_linux/debug/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+


### PR DESCRIPTION
Hi Jan,

Thank you for your repo! Couple minor notes:

When I compile it on Ubuntu 12.04LTS:

```
git clone https://github.com/JanBoonen/TwsApiCpp.git
cd TwsApiCpp/TwsApiC++/_linux/
make
```

I got 71 warning messages (attached as make_on_linux_1st_time.txt) + 1 fatal error message:

```
Assembler messages:
Fatal error: can't create ./debug/TwsApiL0.o: No such file or directory
make: *** [../Api/libTwsApiL0D.a] Error 1
```

to fix an error did:
mkdir ./debug

while in "TwsApiCpp/TwsApiC++/_linux" and then make succeed (still with warnings).

Git does not support empty directories, but there's a solution to add empty folder (with all files ignored by git inside that folder) by adding .gitignore file in the folder with the following content
contend of magical .gitignore file:

```
# Ignore everything in this directory
*
# Except this file
!.gitignore
```

solution was found in this stackoverflow discussion
http://stackoverflow.com/questions/115983/how-can-i-add-an-empty-directory-to-a-git-repository

but still we have 71 warning messages to get rid of:
cat make_after_mkdir.txt | grep warning | wc -l
71

To solve the following warning:

```
../Api/TwsApiL0.h: In member function ‘virtual void EWrapperL0::tickPrice(TickerId, TickType, double, int)’:
../Api/TwsApiL0.h:122:111: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘TickerId {aka long int}’ [-Wformat]
```

I replaced '%d' with '%ld'
in TwsApiCpp/TwsApiC++/Api/TwsApiL0.h, in this macros:

```
#define EWRAPPERL0_DEFAULT(id, name) printf( "#warning: empty default method EWrapperL0::%s(id=%ld) was called!\n", name, id );
```

now we have 87 warnings! ;)

thing is that sometimes id is a long int (like TickerId) and sometimes it is just "int" (like NO_VALID_ID defined in TwsSocketClientErrors.h which we can not change).

if we cast int to (long int) then we down to 56 warnings!

```
#define EWRAPPERL0_DEFAULT(id, name) printf( "#warning: empty default method EWrapperL0::%s(id=%ld) was called!\n", name, (long int)id );
```

and we should use proper static_cast<long int>(id) to make it even safer (same 56 warnings). Final line:

```
#define EWRAPPERL0_DEFAULT(id, name) printf( "#warning: empty default method EWrapperL0::%s(id=%ld) was called!\n", name, static_cast<long int>(id) );
```

---

last warning (producing many similar warning messages) is:

```
../../source/PosixClient/Shared/EClientSocketBaseImpl.h:2821:12: warning: enumeration value ‘AUCTION_VOLUME’ not handled in switch [-Wswitch]
../../source/PosixClient/Shared/EClientSocketBaseImpl.h:2821:12: warning: enumeration value ‘AUCTION_PRICE’ not handled in switch [-Wswitch]
../../source/PosixClient/Shared/EClientSocketBaseImpl.h:2821:12: warning: enumeration value ‘AUCTION_IMBALANCE’ not handled in switch [-Wswitch]
../../source/PosixClient/Shared/EClientSocketBaseImpl.h:2821:12: warning: enumeration value ‘MARK_PRICE’ not handled in switch [-Wswitch]
```

there are two (or more) ways to solve it:
1) modify TwsApiCpp/source/PosixClient/Shared/EClientSocketBaseImpl.h, bu adding 1 line into the case():
default: throw("should never happen");

2) modify makefile to use -Wno-switch-enum to suppress this kind of warnings, but I'd rather not, because those warnings might be useful some other time when they plant a bug

We could also document and ignore those warnings, but since now in my framework there's so many moving pieces, I'd rather strictly defeat all  warnings without any exceptions. So I choose solution "1)" and I'm ok with injecting this one extra line (which make the code better due to  exception thrown in unexpected cases instead of keeping going until code brakes at some less predictable random place..  But since as I recall one of your rule was not to modify IB's content, I'm not adding fix "1)" into my pull request. : )    and I have zero warnings here : ))

best regards,
Dmitry
