### PR TITLE
CMaked and fixed Test

### DIFF
--- a/TwsApiC++/Api/CMakeLists.txt
+++ b/TwsApiC++/Api/CMakeLists.txt
@@ -1,0 +1,18 @@
+project(TWSAPI VERSION 9.71.0)
+
+set(LIBRARY_NAME tws_cpp_api)
+
+set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../Src)
+
+file(GLOB SOURCES ${SRC_DIR}/*.cpp)
+
+add_definitions(-D_REENTRANT -D_DEBUG)
+ 
+include_directories(${API_INCLUDE_DIR} ${SRC_DIR} 
+					${IB_POSIX_CLIENT_INCLUDE_DIR} ${IB_POSIX_CLIENT_SOURCE_DIR})
+
+add_library(${LIBRARY_NAME} ${API_INCLUDES} ${SOURCES} 
+			${IB_POSIX_CLIENT_SOURCES} ${IB_POSIX_CLIENT_INCLUDES})
+set_source_files_properties(${API_INCLUDES} ${IB_POSIX_CLIENT_INCLUDES} ${IB_POSIX_CLIENT_SOURCES}
+						    PROPERTIES HEADER_FILE_ONLY TRUE)
+target_compile_options(${LIBRARY_NAME} PRIVATE -Wall PUBLIC -std=gnu++0x)

--- a/TwsApiC++/CMakeLists.txt
+++ b/TwsApiC++/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+#----------------------------
+# CMAKE DEBUGING
+#----------------------------
+
+# Display a variable.
+macro(display var)
+  message(STATUS "${var}: " ${${var}})
+endmacro()
+
+#----------------------------
+
+set(API_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Api)
+set(IB_POSIX_CLIENT_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../source/PosixClient)
+set(IB_POSIX_CLIENT_INCLUDE_DIR ${IB_POSIX_CLIENT_SRC}/Shared)
+set(IB_POSIX_CLIENT_SOURCE_DIR ${IB_POSIX_CLIENT_SRC}/src)
+
+file(GLOB IB_POSIX_CLIENT_SOURCES ${IB_POSIX_CLIENT_SOURCE_DIR}/*)
+file(GLOB IB_POSIX_CLIENT_INCLUDES ${IB_POSIX_CLIENT_INCLUDE_DIR}/*.h)
+file(GLOB API_INCLUDES ${API_INCLUDE_DIR}/*.h)
+
+add_subdirectory(Api)
+add_subdirectory(Test)

--- a/TwsApiC++/Test/CMakeLists.txt
+++ b/TwsApiC++/Test/CMakeLists.txt
@@ -1,0 +1,26 @@
+project(TWSAPICPP_TEST VERSION 1.0.0)
+
+set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Src)
+
+add_definitions(-D_REENTRANT -D_DEBUG)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+include_directories(${API_INCLUDE_DIR} ${IB_POSIX_CLIENT_INCLUDE_DIR})
+
+add_executable(Test ${SOURCE_DIR}/Test.cpp)
+target_link_libraries(Test tws_cpp_api Threads::Threads)
+target_compile_options(Test PRIVATE -Wall)
+
+add_executable(History ${SOURCE_DIR}/History.cpp)
+target_link_libraries(History tws_cpp_api Threads::Threads)
+target_compile_options(History PRIVATE -Wall)
+
+add_executable(Bars ${SOURCE_DIR}/Bars.cpp)
+target_link_libraries(Bars tws_cpp_api Threads::Threads)
+target_compile_options(Bars PRIVATE -Wall)
+
+add_executable(Clients ${SOURCE_DIR}/Clients.cpp)
+target_link_libraries(Clients tws_cpp_api Threads::Threads)
+target_compile_options(Clients PRIVATE -Wall)

--- a/TwsApiC++/Test/Src/Test.cpp
+++ b/TwsApiC++/Test/Src/Test.cpp
@@ -207,17 +207,18 @@ void TestEnums( void )
 
 struct Contract_ : public Contract
 {
-	Contract_( IBString sb, IBString st, IBString cr, IBString ex )
+	Contract_( IBString sb, IBString st, IBString cr, IBString ex, IBString pr_ex )
 	: Contract()
 	{
-		symbol			= sb;
-		secType			= st;		//"STK"
-		currency		= cr;
-		exchange		= ex;	//"SMART";
+		symbol				= sb;
+		secType				= st;		//"STK"
+		currency			= cr;
+		exchange			= ex;	  	//"SMART";
+		primaryExchange 	= pr_ex;	//"ISLAND";
 	}
 };
 
-Contract_			C( "MSFT", *SecType::STK, "USD", *Exchange::IB_SMART );
+Contract_			C( "MSFT", *SecType::STK, "USD", *Exchange::IB_SMART, *Exchange::ISLAND );
 
 int main( void )
 {
@@ -225,7 +226,7 @@ int main( void )
 
 //	TestEnums();
 
-	Contract_			C( "MSFT", *SecType::STK, "USD", *Exchange::IB_SMART );
+	//Contract_			C( "MSFT", *SecType::STK, "USD", *Exchange::IB_SMART );
 
 /*
 	Contract			C;


### PR DESCRIPTION
Test program was complaining that MSFT contract was ambiguous. This is fixed by specifying the primary exchange.
