### PR TITLE
EPosixClientSocket now gracefully handles EINTR

### DIFF
--- a/source/PosixClient/src/EPosixClientSocket.cpp
+++ b/source/PosixClient/src/EPosixClientSocket.cpp
@@ -205,6 +205,12 @@ bool EPosixClientSocket::handleSocketError()
 	if( errno == EISCONN) {
 		return true;
 	}
+	// A socket syscall was interrupted. Fortunately the rest of the code is already
+	// set up to retry appropriately (unless this function returns false), so this
+	// is all the handling necessary.
+	if( errno == EINTR) {
+		return true;
+	}
 
 	if( errno == EWOULDBLOCK)
 		return false;


### PR DESCRIPTION
Needed to allow a program compiled with `-pg` for gprof to run without its sockets breaking.